### PR TITLE
Fixed incorrect timezone assumption

### DIFF
--- a/KZPropertyMapper/KZPropertyMapper.m
+++ b/KZPropertyMapper/KZPropertyMapper.m
@@ -192,6 +192,7 @@ if(!(condition)) { return pixle_NSErrorMake([NSString stringWithFormat:@"Invalid
     NSLocale *locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
     [df setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss'Z'"];
     [df setLocale:locale];
+    [df setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"UTC"]];
   }
   return df;
 }


### PR DESCRIPTION
The date formatter is assuming UTC times... yet doesn't fix the timezone into this locale, therefor any manipulations and calculations on the date take the systems timezone instead rather than knowing its UTC. Producing inaccurate results if doing something like timeIntervalSince etc
