### PR TITLE
Toggle logging of ignored values in class method, not #define

### DIFF
--- a/KZPropertyMapper/KZPropertyMapper.h
+++ b/KZPropertyMapper/KZPropertyMapper.h
@@ -7,10 +7,10 @@
 
 #import <Foundation/Foundation.h>
 
-#ifndef KZPropertyMapperLogIgnoredValues
-  #define KZPropertyMapperLogIgnoredValues 1
-#endif
-
 @interface KZPropertyMapper : NSObject
 + (void)mapValuesFrom:(id)arrayOrDictionary toInstance:(id)instance usingMapping:(NSDictionary *)parameterMapping;
+@end
+
+@interface KZPropertyMapper (Debug)
++ (void)logIgnoredValues:(BOOL)logIgnoredValues;
 @end

--- a/KZPropertyMapper/KZPropertyMapper.m
+++ b/KZPropertyMapper/KZPropertyMapper.m
@@ -84,18 +84,16 @@ if(!(condition)) { return pixle_NSErrorMake([NSString stringWithFormat:@"Invalid
   if ([mapping isKindOfClass:NSDictionary.class] || [mapping isKindOfClass:NSArray.class]) {
     if ([value isKindOfClass:NSDictionary.class] || [value isKindOfClass:NSArray.class]) {
       [self mapValuesFrom:value toInstance:instance usingMapping:mapping];
-    } else {
-#if KZPropertyMapperLogIgnoredValues
-      NSLog(@"KZPropertyMapper: Ignoring property %@ as it's not in mapping dictionary", propertyName);
-#endif
+    } else if (_shouldLogIgnoredValues) {
+        NSLog(@"KZPropertyMapper: Ignoring property %@ as it's not in mapping dictionary", propertyName);
     }
     return;
   }
 
   if (!mapping) {
-#if KZPropertyMapperLogIgnoredValues
-    NSLog(@"KZPropertyMapper: Ignoring value at index %@ as it's not mapped", propertyName);
-#endif
+    if (_shouldLogIgnoredValues) {
+      NSLog(@"KZPropertyMapper: Ignoring value at index %@ as it's not mapped", propertyName);
+    }
     return;
   }
 
@@ -205,6 +203,19 @@ if(!(condition)) { return pixle_NSErrorMake([NSString stringWithFormat:@"Invalid
   AssertTrueOrReturnNil([target respondsToSelector:selector]);
   id (*objc_msgSendTyped)(id, SEL, id) = (void*)objc_msgSend;
   return objc_msgSendTyped(target, selector, value);
+}
+
+#pragma mark - Logging configuration
+
+#ifdef KZPropertyMapperLogIgnoredValues
+static BOOL _shouldLogIgnoredValues = KZPropertyMapperLogIgnoredValues;
+#else
+static BOOL _shouldLogIgnoredValues = YES;
+#endif
+
++ (void)logIgnoredValues:(BOOL)logIgnoredValues
+{
+  _shouldLogIgnoredValues = logIgnoredValues;
 }
 
 @end


### PR DESCRIPTION
This addresses the issue raised by @andrewsardone in krzysztofzablocki/KZPropertyMapper#10, using his proposed solution.

Users (CocoaPods users in particular) should now use the class method `+[KZPropertyMapper logIgnoredValues:]` to configure whether to log ignored values.

The previous method, via `#define KZPropertyMapperLogIgnoredValues`, will still work but is no longer exposed in the public interface.

Credit to @andrewsardone for the idea and for suggesting that the class method be placed in a Debug category,
to separate it from the class's main concern (that is, mapping stuff).
