### PR TITLE
Allow for mapping to subobjects by using KVC's forKeyPath:

### DIFF
--- a/KZPropertyMapper/KZPropertyMapper.m
+++ b/KZPropertyMapper/KZPropertyMapper.m
@@ -168,7 +168,7 @@
     objc_msgSend(instance, NSSelectorFromString(@"setPrimitiveValue:forKey:"), value, mapping);
     [instance didChangeValueForKey:mapping];
   } else {
-    [instance setValue:value forKey:mapping];
+    [instance setValue:value forKeyPath:mapping];
   }
 }
 


### PR DESCRIPTION
We have a slightly more complex endpoint with what we want to map to 1st class sub objects. In order to map to those values, FKProperty(_subscription.subscriptionState) for instance, then KZPropertyMapper needs to use KVC's setValue: forKeyPath: instead of just forKey:. You also need to disable compile time checking, but I don't have a fix for that yet.
