### PR TITLE
BugFix: NSErrorMake UserInfo

### DIFF
--- a/KZPropertyMapper/KZPropertyMapperCommon.m
+++ b/KZPropertyMapper/KZPropertyMapperCommon.m
@@ -4,7 +4,7 @@
 //
 //
 NSError *pixle_NSErrorMake(NSString *message, NSUInteger code, NSDictionary *aUserInfo, SEL selector) {
-  NSMutableDictionary *userInfo = [aUserInfo mutableCopy];
+  NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:aUserInfo];
   userInfo[NSLocalizedDescriptionKey] = message;
   NSError *error = [NSError errorWithDomain:@"com.pixle.KZPropertyMapper" code:code userInfo:userInfo];
 


### PR DESCRIPTION
The fix will always return a mutable dictionary, ensuring the message is always presented for logging.
