### PR TITLE
Properties that are not part of the MOM, don't notify changes

### DIFF
--- a/KZPropertyMapper.podspec
+++ b/KZPropertyMapper.podspec
@@ -10,6 +10,6 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.8'
   s.source_files = 'KZPropertyMapper/*.{h,m}'
   s.requires_arc = true
-  s.frameworks = 'Foundation'
+  s.frameworks = ['Foundation', 'CoreData'];
 end
 

--- a/KZPropertyMapper/KZPropertyMapper.m
+++ b/KZPropertyMapper/KZPropertyMapper.m
@@ -8,6 +8,7 @@
 #import <objc/message.h>
 #import "KZPropertyMapperCommon.h"
 #import "KZPropertyDescriptor.h"
+#import <CoreData/CoreData.h>
 
 @implementation KZPropertyMapper {
 }
@@ -164,7 +165,8 @@
 + (void)setValue:(id)value withMapping:(NSString *)mapping onInstance:(id)instance
 {
   Class coreDataBaseClass = NSClassFromString(@"NSManagedObject");
-  if (coreDataBaseClass != nil && [instance isKindOfClass:coreDataBaseClass]) {
+  if (coreDataBaseClass != nil && [instance isKindOfClass:coreDataBaseClass] &&
+      [[((NSManagedObject *)instance).entity propertiesByName] valueForKey:mapping]) {
     [instance willChangeValueForKey:mapping];
     void (*objc_msgSendTyped)(id, SEL, id, NSString*) = (void *)objc_msgSend;
     objc_msgSendTyped(instance, NSSelectorFromString(@"setPrimitiveValue:forKey:"), value, mapping);


### PR DESCRIPTION
When extending a Managed Object  to include properties not defined in the Managed Object Model, the mapping causes a crash.

This change ensures only attributes persisted by Core Data go through `willChangeValueForKey:` and `didChangeValueForKey:`.
