### PR TITLE
added if(NO){…} around [target property]

### DIFF
--- a/KZPropertyMapper/KZPropertyMapper.h
+++ b/KZPropertyMapper/KZPropertyMapper.h
@@ -17,9 +17,9 @@
   #define KZPropertyT(target, property) ({[KZPropertyDescriptor descriptorWithPropertyName:@#property andMapping:nil];})
   #define KZCallT(target, method, property) ({[KZPropertyDescriptor descriptorWithPropertyName:@#property selector:@selector(method)];})
 #else
-  #define KZBoxT(target, mapping, property) ({[target property], [KZPropertyDescriptor descriptorWithPropertyName:@#property andMapping:@#mapping];})
-  #define KZPropertyT(target, property) ({[target property], [KZPropertyDescriptor descriptorWithPropertyName:@#property andMapping:nil];})
-  #define KZCallT(target, method, property) ({[target property], [KZPropertyDescriptor descriptorWithPropertyName:@#property selector:@selector(method)];})
+  #define KZBoxT(target, mapping, property) ({if(NO){[target property];} [KZPropertyDescriptor descriptorWithPropertyName:@#property andMapping:@#mapping];})
+  #define KZPropertyT(target, property) ({if(NO){[target property];} [KZPropertyDescriptor descriptorWithPropertyName:@#property andMapping:nil];})
+  #define KZCallT(target, method, property) ({if(NO){[target property];} [KZPropertyDescriptor descriptorWithPropertyName:@#property selector:@selector(method)];})
 #endif
 
 @interface KZPropertyMapper : NSObject


### PR DESCRIPTION
This code should never be called at runtime, it is only intended to provide compile-time errors.

By adding this if statement the code will not be called at runtime, and it will even be optimised out by the compiler. This avoids possibly-undesirable side effects.
